### PR TITLE
Add DEBUG logging to the API

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,13 @@ Changelog
 
 Here you can see the full list of changes between each Nightfall release.
 
+Version 0.4.0
+-------------
+
+UNRELEASED
+
+- Add debug logs to API module
+
 Version 0.3.0
 -------------
 

--- a/nightfall/api.py
+++ b/nightfall/api.py
@@ -37,6 +37,8 @@ class Api():
             'Content-Type': 'application/json',
             'x-api-key': self.token
         }
+        self.logger = logging.getLogger(__name__)
+
 
     def make_payloads(self, data):
         """Turn a list of strings into a list of acceptable payloads.
@@ -101,6 +103,16 @@ class Api():
                 headers=self._headers,
                 data=json.dumps(payload)
             )
+
+            # Logs for Debugging
+            self.logger.debug(f"HTTP Request URL: {response.request.url}")
+            self.logger.debug(f"HTTP Request Body: {response.request.body}")
+            self.logger.debug(f"HTTP Request Headers: {response.request.headers}")
+
+            self.logger.debug(f"HTTP Status Code: {response.status_code}")
+            self.logger.debug(f"HTTP Response Headers: {response.headers}")
+            self.logger.debug(f"HTTP Response Text: {response.text}")
+
             response.raise_for_status()
             responses += response.json()
         


### PR DESCRIPTION
This commit adds debug logs for the request and response. This can be
useful later for debugging purposes when this SDK is being used.