### PR TITLE
Rename main class

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,7 +8,14 @@ Version 0.4.0
 
 UNRELEASED
 
-- Add debug logs to API module
+- Add debug logs to Nightfall module
+- Change primary class name from ``Api`` to ``Nightfall`` to make things a bit 
+  more clear when this library is used in other programs and allow ``from 
+  nightfall import Nightfall``
+
+.. warning::
+    This is a breaking change, since the previous version of this SDK
+    imported Nightfall using ``from nightfall.api import Api``
 
 Version 0.3.0
 -------------

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,13 @@ Changelog
 
 Here you can see the full list of changes between each Nightfall release.
 
+Version 0.4.0
+-------------
+
+UNRELEASED
+
+- Add debug logs to API module
+
 Version 0.3.0
 -------------
 

--- a/README.md
+++ b/README.md
@@ -15,17 +15,16 @@ pip install nightfall
 Make a new [API Token](https://app.nightfall.ai/api/) and [Detection Rule Set](https://app.nightfall.ai/detection-engine/detection-rules) in Nightfall and store the values as environment variables.
 
 ```
-from nightfall import Api
+from nightfall import Nightfall
 
-nightfall = Api(
+nightfall = Nightfall(
     os.getenv('NIGHTFALL_TOKEN'),
     os.getenv('NIGHTFALL_CONDITION_SET')
     )
 
 response = nightfall.scan(['test string'])
 
-findings = response.json()
-print(findings)
+print(response)
 ```
 
 ## Contributing

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,8 +1,8 @@
 API
 ===
 
-API Object
-----------
+Nightfall Object
+----------------
 
 .. automodule:: nightfall.api
     :members:

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -22,14 +22,13 @@ Import Nightfall and start using methods:
 
 ::
 
-    from nightfall import Api
+    from nightfall import Nightfall
 
-    nightfall = Api(
+    nightfall = Nightfall(
         os.getenv('NIGHTFALL_TOKEN'),
         os.getenv('NIGHTFALL_CONDITION_SET')
         )
 
     response = nightfall.scan(['test string'])
 
-    findings = response.json()
-    print(findings)    
+    print(response)    

--- a/nightfall/__init__.py
+++ b/nightfall/__init__.py
@@ -7,3 +7,4 @@ nightfall module
     :copyright: (c) 2021 Nightfall
     :license: MIT, see LICENSE for more details.
 """
+from .api import Nightfall

--- a/nightfall/api.py
+++ b/nightfall/api.py
@@ -10,7 +10,7 @@ import json
 import requests
 import logging
 
-class Api():
+class Nightfall():
     """A python interface for the Nightfall API.
 
     .. data:: MAX_PAYLOAD_SIZE 
@@ -25,7 +25,7 @@ class Api():
     MAX_NUM_ITEMS = 50_000
 
     def __init__(self, token, condition_set):
-        """Instantiate a new nightfall.Api object.
+        """Instantiate a new Nightfall object.
 
         :param token: Your Nightfall API token.
         :param condition_set: Your Nightfall Condition Set UUID
@@ -117,6 +117,3 @@ class Api():
             responses += response.json()
         
         return responses
-
-
-

--- a/nightfall/api.py
+++ b/nightfall/api.py
@@ -37,6 +37,8 @@ class Api():
             'Content-Type': 'application/json',
             'x-api-key': self.token
         }
+        self.logger = logging.getLogger(__name__)
+
 
     def make_payloads(self, data):
         """Turn a list of strings into a list of acceptable payloads.
@@ -101,6 +103,16 @@ class Api():
                 headers=self._headers,
                 data=json.dumps(payload)
             )
+
+            # Logs for Debugging
+            self.logger.debug(f"HTTP Request URL: {response.request.url}")
+            self.logger.debug(f"HTTP Request Body: {response.request.body}")
+            self.logger.debug(f"HTTP Request Headers: {response.request.headers}")
+
+            self.logger.debug(f"HTTP Status Code: {response.status_code}")
+            self.logger.debug(f"HTTP Response Headers: {response.headers}")
+            self.logger.debug(f"HTTP Response Text: {response.text}")
+
             response.raise_for_status()
             responses += response.json()
         

--- a/tests/nightfall/test_api.py
+++ b/tests/nightfall/test_api.py
@@ -3,12 +3,12 @@ import os
 import unittest
 import requests
 
-from nightfall.api import Api
+from nightfall.api import Nightfall
 
 class TestNightfallApi(unittest.TestCase):
 
     def setUp(self):
-        self.client = Api(
+        self.client = Nightfall(
             os.getenv('NIGHTFALL_TOKEN'),
             os.getenv('NIGHTFALL_CONDITION_SET')
             )


### PR DESCRIPTION
This commit renames the main class that we use from `Api` to `Nightfall`
because it makes it a bit more clear about what is going on when you are
using this library in another module.